### PR TITLE
Avoid console.log which is non-standard and implemented differently across browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,19 +24,6 @@ module.exports = {
     this.Events.trigger('render');
   },
 
-  // safe logging
-  log: function() {
-    if (window && window.console) {
-      window.console.log.apply(console, arguments);
-    }
-  },
-
-  dir: function() {
-    if (window && window.console) {
-      window.console.dir.apply(console, arguments);
-    }
-  },
-
   use: function(modules) {
     if (isArray(modules)) {
       transform(modules, extend, this.Modules);


### PR DESCRIPTION
console.log is not a standard function so we can't expect console.log.apply to be defined.
Indeed IE8 and others don't.
See http://www.paulirish.com/2009/log-a-lightweight-wrapper-for-consolelog/
